### PR TITLE
Updated merkleproof page to validate proof using merkletreejs instead of smart contract call

### DIFF
--- a/src/utils/merkle/tree.js
+++ b/src/utils/merkle/tree.js
@@ -50,4 +50,16 @@ const getMerkleProof = (merkleTree, leaf) => {
   return tree.getHexProof(parseLeaf(leaf))
 }
 
-export { generateTree, getMerkleProof, getMerkleRoot, parseLeaf }
+const verifyMerkleProof = (merkleTree, root, leaf, proof) => {
+  const tree = getMerkleTree(merkleTree)
+
+  return tree.verify(proof, parseLeaf(leaf), root)
+}
+
+export {
+  generateTree,
+  getMerkleProof,
+  getMerkleRoot,
+  parseLeaf,
+  verifyMerkleProof
+}


### PR DESCRIPTION
## Change
- Removed smart contract call for validation
- Used `merkletreejs` instead.